### PR TITLE
Change initialization to prevent crash, NEMO#604

### DIFF
--- a/src/server/timed.cpp
+++ b/src/server/timed.cpp
@@ -151,6 +151,8 @@ Timed::Timed(int ac, char **av) :
   init_session_bus() ;
   log_debug() ;
 
+  init_kernel_notification();
+
   init_first_boot_hwclock_time_adjustment_check();
   log_debug() ;
 
@@ -177,8 +179,6 @@ Timed::Timed(int ac, char **av) :
 
   init_apply_tz_settings() ;
   log_debug() ;
-
-  init_kernel_notification() ;
 
   log_info("daemon is up and running") ;
 }


### PR DESCRIPTION
Move init_kernel_notification() to happen before
init_first_boot_hwclock_time_adjustment_check().

If the file /var/cache/timed/first-boot-hwclock.dat
is missing, then timed tries to set the system time in
init_first_boot_hwclock_time_adjustment_check().

The function tries to stop kernel time change
monitoring, which caused timed to segfault as
the object responsible for monitoring time change
was created in init_kernel_notification(), which
was called after
init_first_boot_hwclock_time_adjustment_check().
