### PR TITLE
Allow any user to own the com.nokia.voland service

### DIFF
--- a/src/server/timed.conf
+++ b/src/server/timed.conf
@@ -8,7 +8,9 @@
   </policy>
 
   <policy context="default">
+    <allow own="com.nokia.voland"/>
     <allow send_destination="com.nokia.time"/>
+    <allow send_destination="com.nokia.voland"/>
   </policy>
 
 </busconfig>


### PR DESCRIPTION
Necessary to allow user-run programs to act as the handler for reminder dialogs.
