### PR TITLE
[timed] Use oneshot to set CAP_SYS_TIME required for settimeofday

### DIFF
--- a/rpm/timed-qt5.spec
+++ b/rpm/timed-qt5.spec
@@ -10,7 +10,9 @@ Source0:    %{name}-%{version}.tar.bz2
 Requires:   tzdata
 Requires:   tzdata-timed
 Requires:   systemd
+Requires:   oneshot
 Requires(post): /sbin/ldconfig
+%{_oneshot_requires_post}
 Requires(postun): /sbin/ldconfig
 BuildRequires:  pkgconfig(libpcrecpp)
 BuildRequires:  pkgconfig(Qt5Core)
@@ -21,6 +23,7 @@ BuildRequires:  pkgconfig(dsme_dbus_if)
 BuildRequires:  pkgconfig(systemd)
 BuildRequires:  libiodata-qt5-devel >= 0.19
 BuildRequires:  libxslt
+BuildRequires:  oneshot
 
 %description
 The time daemon (%{name}) managing system time, time zone and settings,
@@ -79,10 +82,11 @@ ln -s ../%{name}.service %{buildroot}%{_libdir}/systemd/user/pre-user-session.ta
 
 # Missing executable flags.
 chmod 755 %{buildroot}%{_datadir}/backup-framework/scripts/timed-restore-script.sh
+chmod 755 %{buildroot}%{_oneshotdir}/setcaps-%{name}.sh
 
 %post
 /sbin/ldconfig
-setcap cap_sys_time+ep %{_bindir}/%{name}
+add-oneshot --now setcaps-%{name}.sh
 if [ "$1" -ge 1 ]; then
 systemctl-user daemon-reload || :
 systemctl-user restart %{name}.service || :
@@ -121,6 +125,7 @@ fi
 # %{_mandir}/man8/timed.8.gz
 %{_libdir}/systemd/user/%{name}.service
 %{_libdir}/systemd/user/pre-user-session.target.wants/%{name}.service
+%{_oneshotdir}/setcaps-%{name}.sh
 
 %files tests
 %defattr(-,root,root,-)

--- a/rpm/timed.spec
+++ b/rpm/timed.spec
@@ -10,7 +10,9 @@ Source0:    %{name}-%{version}.tar.bz2
 Requires:   tzdata
 Requires:   tzdata-timed
 Requires:   systemd
+Requires:   oneshot
 Requires(post): /sbin/ldconfig
+%{_oneshot_requires_post}
 Requires(postun): /sbin/ldconfig
 BuildRequires:  pkgconfig(contextprovider-1.0)
 BuildRequires:  pkgconfig(libpcrecpp)
@@ -19,6 +21,7 @@ BuildRequires:  pkgconfig(dsme_dbus_if)
 BuildRequires:  pkgconfig(systemd)
 BuildRequires:  libiodata-devel >= 0.19
 BuildRequires:  libxslt
+BuildRequires: oneshot
 
 %description
 The time daemon (%{name}) managing system time, time zone and settings,
@@ -82,10 +85,11 @@ ln -s ../%{name}.service %{buildroot}%{_libdir}/systemd/user/pre-user-session.ta
 
 # Missing executable flags.
 chmod 755 %{buildroot}%{_datadir}/backup-framework/scripts/timed-restore-script.sh
+chmod 755 %{buildroot}%{_oneshotdir}/setcaps-%{name}.sh
 
 %post
 /sbin/ldconfig
-setcap cap_sys_time+ep %{_bindir}/%{name}
+add-oneshot --now setcaps-%{name}.sh
 if [ "$1" -ge 1 ]; then
 systemctl-user daemon-reload || :
 systemctl-user restart %{name}.service || :
@@ -124,6 +128,7 @@ fi
 # %{_mandir}/man8/timed.8.gz
 %{_libdir}/systemd/user/%{name}.service
 %{_libdir}/systemd/user/pre-user-session.target.wants/%{name}.service
+%{_oneshotdir}/setcaps-%{name}.sh
 
 %files tests
 %defattr(-,root,root,-)

--- a/src/server/server.pro
+++ b/src/server/server.pro
@@ -125,17 +125,20 @@ equals(QT_MAJOR_VERSION, 4) {
     timedrc.files = timed.rc
     dbusconf.files = timed.conf
     systemd.files = timed.service
+    oneshot.files = setcaps-timed.sh
 }
 equals(QT_MAJOR_VERSION, 5) {
     timedrc.files = timed-qt5.rc
     dbusconf.files = timed-qt5.conf
     systemd.files = timed-qt5.service
+    oneshot.files = setcaps-timed-qt5.sh
 }
 timedrc.path  = $$(DESTDIR)/etc
 dbusconf.path  = $$(DESTDIR)/etc/dbus-1/system.d
 systemd.path = $$(DESTDIR)/usr/lib/systemd/user
+oneshot.path = $$(DESTDIR)/usr/lib/oneshot.d
 
-INSTALLS += target xml backupconf backupscripts cud rfs aegishelper aegisfs timedrc dbusconf systemd
+INSTALLS += target xml backupconf backupscripts cud rfs aegishelper aegisfs timedrc dbusconf systemd oneshot
 
 CONFIG(MEEGO) \
 {
@@ -152,3 +155,5 @@ else \
 }
 
 QMAKE_CXXFLAGS  += -Wall
+
+OTHER_FILES += *.sh

--- a/src/server/setcaps-timed-qt5.sh
+++ b/src/server/setcaps-timed-qt5.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+setcap cap_sys_time+ep /usr/bin/timed-qt5

--- a/src/server/setcaps-timed.sh
+++ b/src/server/setcaps-timed.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+setcap cap_sys_time+ep /usr/bin/timed


### PR DESCRIPTION
Setting caps directly in the post install phase does not work during image cretion. Oneshot either sets the caps during install or defers the action to the next boot if setting caps fails. See https://github.com/nemomobile/oneshot/blob/master/README
