### PR TITLE
[timed] Change location of time zone link that timed manages

### DIFF
--- a/rpm/timed-qt5.spec
+++ b/rpm/timed-qt5.spec
@@ -11,8 +11,10 @@ Requires:   tzdata
 Requires:   tzdata-timed
 Requires:   systemd
 Requires:   oneshot
-Requires(post): /sbin/ldconfig
+%{_oneshot_groupadd_requires_pre}
 %{_oneshot_requires_post}
+%{_oneshot_groupadd_requires_post}
+Requires(post): /sbin/ldconfig
 Requires(postun): /sbin/ldconfig
 BuildRequires:  pkgconfig(libpcrecpp)
 BuildRequires:  pkgconfig(Qt5Core)
@@ -84,7 +86,20 @@ ln -s ../%{name}.service %{buildroot}%{_libdir}/systemd/user/pre-user-session.ta
 chmod 755 %{buildroot}%{_datadir}/backup-framework/scripts/timed-restore-script.sh
 chmod 755 %{buildroot}%{_oneshotdir}/setcaps-%{name}.sh
 
+# Timed changes time zone by linking /var/lib/timed/localtime to zones in /usr/share/zoneinfo.
+# Initial links are done in the post section
+install -d %{buildroot}/var/lib/timed
+touch %{buildroot}/var/lib/timed/localtime
+
+%pre
+groupadd -rf timed
+groupadd-user timed
+
 %post
+# Make /etc/localtime a link to /var/lib/timed/localtime to make system time zone follow timed.
+ln -sf /usr/share/zoneinfo/Europe/Helsinki /var/lib/timed/localtime
+ln -sf /var/lib/timed/localtime /etc/localtime
+
 /sbin/ldconfig
 add-oneshot --now setcaps-%{name}.sh
 if [ "$1" -ge 1 ]; then
@@ -102,6 +117,7 @@ fi
 if [ "$1" -eq 0 ]; then
 systemctl-user stop {%name}.service || :
 systemctl-user daemon-reload || :
+getent group time >/dev/null && groupdel timed
 fi
 
 %files
@@ -126,6 +142,8 @@ fi
 %{_libdir}/systemd/user/%{name}.service
 %{_libdir}/systemd/user/pre-user-session.target.wants/%{name}.service
 %{_oneshotdir}/setcaps-%{name}.sh
+%dir %attr(0774,-,timed) /var/lib/timed
+%ghost /var/lib/timed/localtime
 
 %files tests
 %defattr(-,root,root,-)


### PR DESCRIPTION
Timed links time zone files in /usr/share/zoneinfo to
/var/lib/timed, for example

  /var/lib/timed/localtime -> /usr/share/zoneinfo/Europe/Helsinki

The system time zone /etc/localtime is in turn linked to
/var/lib/timed/localtime, so that it follows the time zone
set by timed.

These changes are required as timed is not run with root
priviledges, and it does not have the rights to change
/etc/localtime.
