### PR TITLE
[timed] API for getting a signal when alarm queue changes

### DIFF
--- a/src/doc/libtimed.3.txt
+++ b/src/doc/libtimed.3.txt
@@ -32,6 +32,7 @@ SYNOPSIS
 *class Maemo::Timed::Event::Button ;*
 *class Maemo::Timed::Event::Recurrence ;*
 *class Maemo::Timed::Event::List ;*
+*class Maemo::Timed::Event::Triggers ;*
 
 [verse]
 *class Maemo::Timed::Event::DBusReply ;*
@@ -71,6 +72,24 @@ DAEMON INTERFACE
   The meaning of the slot parameters: the Info structure is described below in
   'WALL CLOCK HANDLING'. The 'time_changed' flas is set iff the system time
   was changed (not only the settings).
+  +
+  bool *alarm_triggers_changed_connect*(QObject &ast; object, const char &ast; slot) -
+  connects the given object/slot pair to the D-Bus signal sent by the daemon
+  when alarm queue changes. Return value indicates if the connection was
+  performed.
+  +
+  bool *alarm_triggers_changed_disconnect*(QObject &ast; object, const char &ast; slot) -
+  disconnects the given object/slot pair from the D-Bus signal sent by the daemon
+  when the alarm queue changes. Returns true if the disconnection was
+  successful.
+  +
+  The 'slot' must have the signature
+  'void alarm_triggers_changed(const Maemo::Timed::Event::Triggers)'.
+  If not, then the call will fail, no signal will be delivered, and a
+  warning
+  will be printed by Qt library (which is nowhere documented through).
+  The parameter 'Maemo::Timed::Event::Triggers' is a QMap<quint32,quint32>,
+  where the keys are cookies and values trigger times as seconds since Unix epoch.
 //  +
 //  Qt signals provided by the class and mirroring the D-Bus signals sent by the
 //  daemon:
@@ -1229,6 +1248,13 @@ class *Maemo::Timed::Event::Action*::
   +
   void *removeCredentialAccrue(const QString &token)* - removes the accrued
   credential with geven token.
+
+*class Maemo::Timed::Event::Triggers*::
+  This class represents the queue of currently active alarms. The class inherits
+  QMap<quint32, quint32>, the keys of the map are are cookies and values trigger
+  times as seconds since Unix epoch. A client application can obtain an instance
+  of this class by subscribing to the 'alarm_triggers_changed' D-Bus signal, see
+  'alarm_triggers_changed_connect' and 'alarm_triggers_changed_disconnect'
 
 EXCEPTIONS
 ----------

--- a/src/lib/event-declarations.h
+++ b/src/lib/event-declarations.h
@@ -56,6 +56,7 @@ public:
   class Button ;
   class Recurrence ;
   class List ;
+  class Triggers;
   typedef event_io_t IO ;
   typedef qdbus_reply_wrapper<Maemo::Timed::Event> DBusReply ;
   typedef qdbus_pending_reply_wrapper<Maemo::Timed::Event> DBusPendingReply ;
@@ -318,6 +319,16 @@ private:
   List(const event_list_io_t &eeio) ;
   QVariant dbus_output() const ;
 } ;
+
+declare_qtdbus_io(Maemo::Timed::Event::Triggers);
+
+class Maemo::Timed::Event::Triggers : public QMap<quint32, quint32>
+{
+public:
+  Triggers() : QMap<quint32, quint32>()
+  {
+  }
+};
 
 #if NOT_DONE_YET
 void foo()

--- a/src/lib/event-pimple.cpp
+++ b/src/lib/event-pimple.cpp
@@ -1316,6 +1316,38 @@ Maemo::Timed::Event::List::List(const event_list_io_t &eeio)
   }
 }
 
+QDBusArgument &operator<<(QDBusArgument &out, const Maemo::Timed::Event::Triggers &map)
+{
+  out.beginMap(QVariant::UInt, QVariant::UInt);
+  QMapIterator<uint, uint> iter(map);
+  while (iter.hasNext()) {
+    iter.next();
+    out.beginMapEntry();
+    out << iter.key() << iter.value();
+    out.endMapEntry();
+  }
+  out.endMap();
+  return out;
+}
+
+const QDBusArgument &operator>>(const QDBusArgument &in, Maemo::Timed::Event::Triggers &map)
+{
+  map.clear();
+  in.beginMap();
+  while (!in.atEnd()) {
+    uint key;
+    uint value;
+    in.beginMapEntry();
+    in >> key >> value;
+    in.endMapEntry();
+    map.insert(key, value);
+  }
+  in.endMap();
+  return in;
+}
+
+register_qtdbus_metatype(Maemo::Timed::Event::Triggers, 11);
+
 #if 0
 int Maemo::Timed::Event::check(QString *err, bool exc) const
 {

--- a/src/lib/interface.cpp
+++ b/src/lib/interface.cpp
@@ -46,6 +46,28 @@ bool Maemo::Timed::Interface::settings_changed_disconnect(QObject *object, const
   return Maemo::Timed::bus().disconnect(s,o,i,"settings_changed",object,slot) ;
 }
 
+bool Maemo::Timed::Interface::alarm_triggers_changed_connect(QObject *object, const char *slot)
+{
+  const char *s = Maemo::Timed::service();
+  const char *o = Maemo::Timed::objpath();
+  const char *i = Maemo::Timed::interface();
+  const char *alarm_trigger_changed_signal = SIGNAL(alarm_triggers_changed(Maemo::Timed::Event::Triggers));
+  if (QObject::connect(this, alarm_trigger_changed_signal, object, slot)) {
+    QObject::disconnect(this, alarm_trigger_changed_signal, object, slot);
+    return Maemo::Timed::bus().connect(s, o, i, "alarm_triggers_changed", object, slot);
+  } else {
+    return false;
+  }
+}
+
+bool Maemo::Timed::Interface::alarm_triggers_changed_disconnect(QObject *object, const char *slot)
+{
+  const char *s = Maemo::Timed::service();
+  const char *o = Maemo::Timed::objpath();
+  const char *i = Maemo::Timed::interface();
+  return Maemo::Timed::bus().disconnect(s, o, i, "alarm_triggers_changed", object, slot);
+}
+
 Maemo::Timed::Interface::Interface(QObject *parent)
   : QDBusAbstractInterface(Maemo::Timed::service(), Maemo::Timed::objpath(), Maemo::Timed::interface(), Maemo::Timed::bus(), parent)
 {

--- a/src/lib/interface.h
+++ b/src/lib/interface.h
@@ -45,6 +45,8 @@ Q_DECLARE_METATYPE(Q_List_uint) ;
 Q_DECLARE_METATYPE(Q_Map_String_String) ;
 Q_DECLARE_METATYPE(Q_Map_uint_String_String) ;
 
+register_qtdbus_metatype(Maemo::Timed::Event::Triggers, 11);
+
 namespace Maemo
 {
   namespace Timed
@@ -75,12 +77,15 @@ namespace Maemo
       // void xxx(bool yyy) { /* emit settings_changed_1(yyy) ; */ }
     signals:
        void settings_changed(const Maemo::Timed::WallClock::Info &info, bool time_changed) ;
+       void alarm_triggers_changed(Maemo::Timed::Event::Triggers);
       // void settings_changed_1(bool time_changed) ;
     public:
       Interface(QObject *parent=NULL) ;
       // -- dbus signals -- //
       bool settings_changed_connect(QObject *object, const char *slot) ;
       bool settings_changed_disconnect(QObject *object, const char *slot) ;
+      bool alarm_triggers_changed_connect(QObject *object, const char *slot);
+      bool alarm_triggers_changed_disconnect(QObject *object, const char *slot);
       // -- application methods -- //
       qtdbus_method(get_wall_clock_info, (void)) ;
       qtdbus_method(wall_clock_settings, (const Maemo::Timed::WallClock::Settings &s), s.dbus_output(__PRETTY_FUNCTION__)) ;

--- a/src/server/adaptor.h
+++ b/src/server/adaptor.h
@@ -76,6 +76,7 @@ signals:
   void settings_changed(const Maemo::Timed::WallClock::Info &, bool) ;
   void settings_changed_1(bool) ;
   void next_bootup_event(int next_boot_event, int next_non_boot_event);
+  void alarm_triggers_changed(Maemo::Timed::Event::Triggers);
 
 public slots:
 

--- a/src/server/timed.cpp
+++ b/src/server/timed.cpp
@@ -1270,6 +1270,18 @@ void Timed::set_alarm_present(bool present)
 
 void Timed::set_alarm_trigger(const QMap<QString, QVariant> &triggers)
 {
+  Maemo::Timed::Event::Triggers triggerMap;
+  QMapIterator<QString, QVariant> iter(triggers);
+  while (iter.hasNext()) {
+    iter.next();
+    uint cookie = iter.key().toUInt();
+    // The alarm_triggers are reported as nanoseconds since epoch, cf. cluster_queue_t::enter
+    // Convert the time to seconds since epoch, corresponding to QDateTime::toTime_t()
+    quint64 tmp = iter.value().toULongLong() / (quint64) nanotime_t::NANO;
+    quint32 seconds_after_epoch = (quint32) tmp;
+    triggerMap.insert(cookie, seconds_after_epoch);
+  }
+  emit alarm_triggers_changed(triggerMap);
 #if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
   // statefs supports only boolean and string types, marshall the QMap to a string
   QString contextProperty = "";

--- a/src/server/timed.h
+++ b/src/server/timed.h
@@ -173,6 +173,7 @@ Q_SIGNALS:
   void voland_unregistered() ;
   void settings_changed(const Maemo::Timed::WallClock::Info &, bool system_time) ;
   void next_bootup_event(int next_boot_event, int next_non_boot_event);
+  void alarm_triggers_changed(Maemo::Timed::Event::Triggers);
   // void settings_changed_1(bool system_time) ;
 public:
   Timed(int ac, char **av) ;


### PR DESCRIPTION
Add public api for subscribing to a signal providing currently
active alarms which is emitted every time the alarm queue
changes.

See documentation for alarm_triggers_changed_connect(), and
alarm_triggers_changed_disconnect() in src/doc/libtimed.3.txt
for more information.
