### PR TITLE
[timed] Prefer ANDROID_ALARM_ELAPSED_REALTIME over CLOCK_MONOTONIC

### DIFF
--- a/src/lib/android_alarm.h
+++ b/src/lib/android_alarm.h
@@ -1,0 +1,59 @@
+/* include/linux/android_alarm.h
+ *
+ * Copyright (C) 2006-2007 Google, Inc.
+ *
+ * This software is licensed under the terms of the GNU General Public
+ * License version 2, as published by the Free Software Foundation, and
+ * may be copied, distributed, and modified under those terms.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ */
+
+#ifndef _LINUX_ANDROID_ALARM_H
+#define _LINUX_ANDROID_ALARM_H
+
+enum android_alarm_type {
+	/* return code bit numbers or set alarm arg */
+	ANDROID_ALARM_RTC_WAKEUP,
+	ANDROID_ALARM_RTC,
+	ANDROID_ALARM_ELAPSED_REALTIME_WAKEUP,
+	ANDROID_ALARM_ELAPSED_REALTIME,
+	ANDROID_ALARM_SYSTEMTIME,
+
+	ANDROID_ALARM_TYPE_COUNT,
+
+	/* return code bit numbers */
+	/* ANDROID_ALARM_TIME_CHANGE = 16 */
+};
+
+enum android_alarm_return_flags {
+	ANDROID_ALARM_RTC_WAKEUP_MASK = 1U << ANDROID_ALARM_RTC_WAKEUP,
+	ANDROID_ALARM_RTC_MASK = 1U << ANDROID_ALARM_RTC,
+	ANDROID_ALARM_ELAPSED_REALTIME_WAKEUP_MASK =
+				1U << ANDROID_ALARM_ELAPSED_REALTIME_WAKEUP,
+	ANDROID_ALARM_ELAPSED_REALTIME_MASK =
+				1U << ANDROID_ALARM_ELAPSED_REALTIME,
+	ANDROID_ALARM_SYSTEMTIME_MASK = 1U << ANDROID_ALARM_SYSTEMTIME,
+	ANDROID_ALARM_TIME_CHANGE_MASK = 1U << 16
+};
+
+/* Disable alarm */
+#define ANDROID_ALARM_CLEAR(type)           _IO('a', 0 | ((type) << 4))
+
+/* Ack last alarm and wait for next */
+#define ANDROID_ALARM_WAIT                  _IO('a', 1)
+
+#define ALARM_IOW(c, type, size)            _IOW('a', (c) | ((type) << 4), size)
+/* Set alarm */
+#define ANDROID_ALARM_SET(type)             ALARM_IOW(2, type, struct timespec)
+#define ANDROID_ALARM_SET_AND_WAIT(type)    ALARM_IOW(3, type, struct timespec)
+#define ANDROID_ALARM_GET_TIME(type)        ALARM_IOW(4, type, struct timespec)
+#define ANDROID_ALARM_SET_RTC               _IOW('a', 5, struct timespec)
+#define ANDROID_ALARM_BASE_CMD(cmd)         (cmd & ~(_IOC(0, 0, 0xf0, 0)))
+#define ANDROID_ALARM_IOCTL_TO_TYPE(cmd)    (_IOC_NR(cmd) >> 4)
+
+#endif

--- a/src/lib/androidalarmwrapper.cpp
+++ b/src/lib/androidalarmwrapper.cpp
@@ -1,0 +1,61 @@
+/***************************************************************************
+**                                                                        **
+**  Copyright (C) 2013 Jolla Ltd.                                         **
+**  Contact: Petri M. Gerdt <petri.gerdt@jollamobile.com>                 **
+**                                                                        **
+**     This file is part of Timed                                         **
+**                                                                        **
+**     Timed is free software; you can redistribute it and/or modify      **
+**     it under the terms of the GNU Lesser General Public License        **
+**     version 2.1 as published by the Free Software Foundation.          **
+**                                                                        **
+**     Timed is distributed in the hope that it will be useful, but       **
+**     WITHOUT ANY WARRANTY;  without even the implied warranty  of       **
+**     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               **
+**     See the GNU Lesser General Public License  for more details.       **
+**                                                                        **
+**   You should have received a copy of the GNU  Lesser General Public    **
+**   License along with Timed. If not, see http://www.gnu.org/licenses/   **
+**                                                                        **
+***************************************************************************/
+
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+
+#include "androidalarmwrapper.h"
+#include "android_alarm.h"
+#include "../common/log.h"
+
+static const char android_alarm_path[] = "/dev/alarm";
+
+AndroidAlarmWrapper::AndroidAlarmWrapper()
+{
+    if((m_android_alarm_fd = open(android_alarm_path, O_RDONLY)) == -1 ) {
+        /* Using /dev/alarm is optional; do not complain if it is missing */
+        if(errno != ENOENT)
+            log_warning("Failed to open %s: %m", android_alarm_path);
+    }
+}
+
+AndroidAlarmWrapper::~AndroidAlarmWrapper()
+{
+    if (m_android_alarm_fd != -1) {
+        close(m_android_alarm_fd);
+        m_android_alarm_fd = -1;
+    }
+}
+
+int AndroidAlarmWrapper::getTime(struct timespec *ts)
+{
+    if (m_android_alarm_fd == -1)
+        return -1;
+
+    int cmd = ANDROID_ALARM_GET_TIME(ANDROID_ALARM_ELAPSED_REALTIME);
+    int res = ioctl(m_android_alarm_fd, cmd, ts);
+    if (res < 0)
+        log_warning("Failed to get ANDROID_ALARM_ELAPSED_REALTIME %m");
+
+    return res;
+}

--- a/src/lib/androidalarmwrapper.h
+++ b/src/lib/androidalarmwrapper.h
@@ -1,0 +1,35 @@
+/***************************************************************************
+**                                                                        **
+**  Copyright (C) 2013 Jolla Ltd.                                         **
+**  Contact: Petri M. Gerdt <petri.gerdt@jollamobile.com>                 **
+**                                                                        **
+**     This file is part of Timed                                         **
+**                                                                        **
+**     Timed is free software; you can redistribute it and/or modify      **
+**     it under the terms of the GNU Lesser General Public License        **
+**     version 2.1 as published by the Free Software Foundation.          **
+**                                                                        **
+**     Timed is distributed in the hope that it will be useful, but       **
+**     WITHOUT ANY WARRANTY;  without even the implied warranty  of       **
+**     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               **
+**     See the GNU Lesser General Public License  for more details.       **
+**                                                                        **
+**   You should have received a copy of the GNU  Lesser General Public    **
+**   License along with Timed. If not, see http://www.gnu.org/licenses/   **
+**                                                                        **
+***************************************************************************/
+
+#ifndef ANDROIDALARMFDWRAPPER_H
+#define ANDROIDALARMFDWRAPPER_H
+
+class AndroidAlarmWrapper
+{
+public:
+    AndroidAlarmWrapper();
+    ~AndroidAlarmWrapper();
+    int getTime(struct timespec *ts);
+private:
+    int m_android_alarm_fd;
+};
+
+#endif // ANDROIDALARMFDWRAPPER_H

--- a/src/lib/lib.pro
+++ b/src/lib/lib.pro
@@ -8,10 +8,10 @@ equals(QT_MAJOR_VERSION, 5): TARGET = timed-qt5
 
 VERSION = 0.$$(TIMED_VERSION)
 
-HEADERS = interface.h
+HEADERS = interface.h androidalarmwrapper.h
 SOURCES = interface.cpp event-io.cpp event-pimple.cpp exception.cpp nanotime.cpp imagetype.cpp aliases.cpp
 
-SOURCES += wall-settings.cpp wall-info.cpp qmacro.cpp
+SOURCES += wall-settings.cpp wall-info.cpp qmacro.cpp androidalarmwrapper.cpp
 
 LIBS += -lrt
 

--- a/src/lib/nanotime.cpp
+++ b/src/lib/nanotime.cpp
@@ -28,6 +28,7 @@
 
 #include "nanotime.h"
 #include "../common/log.h"
+#include "androidalarmwrapper.h"
 
 nanotime_t nanotime_t::div2() const
 {
@@ -63,9 +64,16 @@ nanotime_t nanotime_t::systime_now()
 
 nanotime_t nanotime_t::monotonic_now()
 {
-  struct timespec tv ;
-  int res = clock_gettime(CLOCK_MONOTONIC, &tv) ;
-  nanotime_t t = nanotime_t::from_timespec(tv) ;
+  static AndroidAlarmWrapper wrapper;
+  struct timespec ts;
+  int res = wrapper.getTime(&ts);
+
+  if (res < 0) {
+    res = clock_gettime(CLOCK_MONOTONIC, &ts);
+  }
+
+  nanotime_t t = nanotime_t::from_timespec(ts);
+
   if(res<0)
     t.invalidate() ;
   else


### PR DESCRIPTION
The CLOCK_MONOTONIC might get frozen during suspend. The android specific ANDROID_ALARM_ELAPSED_REALTIME does not have this problem and should be used when available.

See https://github.com/nemomobile/dsme/pull/29 similar changes in dsme.
