### PR TITLE
[timed] Recalculate alarm timer trigger when time changes

### DIFF
--- a/src/server/notification.h
+++ b/src/server/notification.h
@@ -23,6 +23,7 @@ private Q_SLOTS:
   void ready_to_read(int fd) ;
 Q_SIGNALS:
   void system_time_changed(const nanotime_t &) ;
+  void restart_alarm_timer();
 } ;
 
 

--- a/src/server/timed.cpp
+++ b/src/server/timed.cpp
@@ -1218,6 +1218,7 @@ void Timed::init_kernel_notification()
 {
   notificator = new kernel_notification_t ;
   QObject::connect(notificator, SIGNAL(system_time_changed(const nanotime_t &)), this, SLOT(kernel_notification(const nanotime_t &))) ;
+  QObject::connect(notificator, SIGNAL(restart_alarm_timer()), this, SLOT(restart_alarm_timer()));
   notificator->start() ;
 }
 
@@ -1225,6 +1226,12 @@ void Timed::kernel_notification(const nanotime_t &jump_forwards)
 {
   log_notice("KERNEL: system time changed by %s", jump_forwards.str().c_str()) ;
   settings->process_kernel_notification(jump_forwards) ;
+}
+
+void Timed::restart_alarm_timer()
+{
+  log_debug();
+  machine_t::pause_t p(am);
 }
 
 void Timed::init_first_boot_hwclock_time_adjustment_check() {

--- a/src/server/timed.h
+++ b/src/server/timed.h
@@ -236,6 +236,7 @@ private Q_SLOTS:
   void harmattan_init_done(int runlevel) ;
   void harmattan_desktop_visible() ;
   void kernel_notification(const nanotime_t &jump_forwards) ;
+  void restart_alarm_timer();
   void set_alarm_present(bool present);
   void set_alarm_trigger(const QMap<QString, QVariant> &triggers);
 public:


### PR DESCRIPTION
The QTimer tracking next alarm trigger time may ignore time spent in suspend, recalculating the trigger time will update the next alarm trigger time.
