### PR TITLE
[timed] Do not trigger alarms via event queue

### DIFF
--- a/src/server/state.cpp
+++ b/src/server/state.cpp
@@ -395,7 +395,7 @@ void state_queued_t::timer_start()
     log_notice("go to sleep, next alarm in %s seconds", time_to_wait.str().c_str()) ;
 
   if(no_sleep)
-    alarm_timer->start(0) ;
+    alarm_timeout();
   else
   {
     static const int threshold = 3600+1 ; // One hour


### PR DESCRIPTION
In some rare cases the event queue may contain events that cancel/reprogram the alarm.

The QTimer alarm_timer signal triggered is connected to slot alarm_timeout, this pull request  bypasses the timer and calls the slot directly.
