### PR TITLE
Revert "[timed] Use invoker to start timed-qt5.service"

### DIFF
--- a/src/server/timed-qt5.service
+++ b/src/server/timed-qt5.service
@@ -1,11 +1,10 @@
 [Unit]
 Description=Time Daemon
 Requires=dbus.socket
-After=booster-generic.service
 
 [Service]
 Type=notify
-ExecStart=/usr/bin/invoker -s --type=generic /usr/bin/timed-qt5 --systemd
+ExecStart=/usr/bin/timed-qt5 --systemd
 Restart=always
 
 [Install]


### PR DESCRIPTION
This reverts commit f2959ec780ead5537a2b5f712b469c5052aa2c5e.

Do not use invoker to start timed, the startup gain is much less than the time that may be spent waiting for the invoker to be initialized/started during boot.

If timed needs to be in the priviledged group [1] granted when using invoker, then it is better to add timed to the priviledged group by setting the gid in the spec file like so: %attr(2755, root, privileged) %{_bindir}/%{name}

[1] https://github.com/nemomobile/mapplauncherd/commit/a063dfc7da0af971db97feabacc19c021872efde
