### PR TITLE
[timed] Do not disable automatic time management when system time changes

### DIFF
--- a/src/server/settings.cpp
+++ b/src/server/settings.cpp
@@ -643,21 +643,9 @@ bool source_settings::wall_clock_settings(const Maemo::Timed::WallClock::wall_se
 
 void source_settings::process_kernel_notification(const nanotime_t &jump_forwards)
 {
-  // 1. Disable auto time update
-  time_nitz = false ;
-
-  // 2. If auto zone update => update manual zone
-  if (local_cellular and cellular_zone->available())
-    manual_zone->value = cellular_zone->value ;
-
-  // 3. Disable auto zone
-  local_cellular = false ;
-
-  // 4. invoke signal (fake value of 1.000000239 second)
-  // o->invoke_signal(nanotime_t(1,239)) ; // TODO: real time jump value needed !!! XXX
   o->invoke_signal(-jump_forwards) ;
 
-  // 5. make time valid
+  // Make time valid
   o->open_epoch() ;
 }
 


### PR DESCRIPTION
With this change timed will not disable automatic time management via NITZ unless explicitly told so via Maemo::Timed::WallClock::Settings::setTimeManual().

When automatic time update is enabled, and the system time is changed, then timed will change the system time back according to the next NITZ signal it receives. Timed will query ofono for NITZ data when it reboots, too.
