### PR TITLE
[timed] Trigger recurring events missed by <59 secs during startup

### DIFF
--- a/src/server/event.cpp
+++ b/src/server/event.cpp
@@ -44,6 +44,7 @@ event_t::event_t()
   state = NULL ;
   request_watcher = NULL ;
   cookie = cookie_t(0) ; // paranoid
+  trigger_if_missed = false;
 }
 
 event_t::~event_t()

--- a/src/server/event.h
+++ b/src/server/event.h
@@ -134,6 +134,10 @@ struct event_t
   cred_modifier_t *cred_modifier ;
   credentials_t *client_creds ;
 
+  // If the event has recurrences, then it needs to be triggered if it was missed by
+  // RenameMeNameSpace::Missing_Threshold when timed starts. event_t::trigger_if_missed
+  // is used to indicate this.
+  bool trigger_if_missed;
 
   vector<recurrence_pattern_t> recrs ;
   vector<action_t> actions ;

--- a/src/server/machine.h
+++ b/src/server/machine.h
@@ -92,6 +92,7 @@ struct machine_t : public QObject
   void unregister_event(event_t *e) ;
   bool is_event_registered(event_t *e) ;
   void send_queue_context() ;
+  qlonglong running_time();
   Q_OBJECT ;
 public Q_SLOTS:
   void online_state_changed(bool connected) ;
@@ -124,6 +125,7 @@ public:
 private:
   string s_states() ;
   string s_transition_queue() ;
+  time_t startup_time;
 
 public:
   // states

--- a/src/server/state.h
+++ b/src/server/state.h
@@ -252,7 +252,7 @@ struct state_recurred_t : public abstract_state_t
   state_recurred_t(machine_t *owner) : abstract_state_t("RECURRED", owner) { }
   virtual ~state_recurred_t() { }
   void enter(event_t *e) ;
-  ticker_t apply_pattern(const broken_down_t &t, int wday, const recurrence_pattern_t *p) ;
+  ticker_t apply_pattern(const broken_down_t &t, int wday, const recurrence_pattern_t *p, qlonglong offset = 0);
 } ;
 
 struct state_armed_t : public abstract_gate_state_t

--- a/src/server/timeutil.cpp
+++ b/src/server/timeutil.cpp
@@ -391,9 +391,8 @@ time_t broken_down_t::mktime_strict(int dst /* = -1 */) const
   return t ;
 }
 
-void broken_down_t::from_time_t(const ticker_t &ticker, int *wday)
+void broken_down_t::from_time_t(const time_t &time, int *wday)
 {
-  time_t time = ticker.value() ;
   struct tm tm ;
   localtime_r(&time, &tm) ;
   if(wday)

--- a/src/server/timeutil.h
+++ b/src/server/timeutil.h
@@ -65,7 +65,7 @@ struct broken_down_t
   bool is_valid() const ;
   struct tm *to_struct_tm(struct tm *dest=NULL) const ;
   void from_struct_tm(const struct tm *) ;
-  void from_time_t(const ticker_t &ticker, int *wday=NULL) ;
+  void from_time_t(const time_t &time, int *wday=NULL);
   bool same_struct_tm(const struct tm *) const ;
   void increment_day() ;
   bool find_a_good_day(const recurrence_pattern_t *p, int &wday, bool &today, unsigned max_year) ;


### PR DESCRIPTION
When a recurring event is loaded, then set the flag trigger_if_missed (see machine.cpp 778-779). Then, when calculating the next recurrence for the event, check if timed has been running for less than 59 seconds. If that is the case, and the flag trigger_if_missed is set, then calculate the next trigger time as if the event should go off 59 seconds - current running time in the past.

When an alarm with the trigger_if_missed flag is triggered, then the flag is set to false in state_triggered_t::enter(..).
