### PR TITLE
[timed] Wait for D-bus service to be available before starting

### DIFF
--- a/src/server/timed-qt5.service
+++ b/src/server/timed-qt5.service
@@ -1,11 +1,13 @@
 [Unit]
 Description=Time Daemon
 Requires=dbus.socket
+After=dbus.socket
 
 [Service]
 Type=notify
 ExecStart=/usr/bin/timed-qt5 --systemd
 Restart=always
+RestartSec=1
 
 [Install]
 WantedBy=pre-user-session.target


### PR DESCRIPTION
Timed both uses and provides D-bus services, do not start before D-bus is available.
