### PR TITLE
[timed] Enable connman NTP time synch when NITZ time management is enabled

### DIFF
--- a/src/server/ntpcontroller.cpp
+++ b/src/server/ntpcontroller.cpp
@@ -1,0 +1,88 @@
+/***************************************************************************
+**                                                                        **
+**  Copyright (C) 2013 Jolla Ltd.                                         **
+**  Contact: Petri M. Gerdt <petri.gerdt@jollamobile.com>                 **
+**                                                                        **
+**     This file is part of Timed                                         **
+**                                                                        **
+**     Timed is free software; you can redistribute it and/or modify      **
+**     it under the terms of the GNU Lesser General Public License        **
+**     version 2.1 as published by the Free Software Foundation.          **
+**                                                                        **
+**     Timed is distributed in the hope that it will be useful, but       **
+**     WITHOUT ANY WARRANTY;  without even the implied warranty  of       **
+**     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               **
+**     See the GNU Lesser General Public License  for more details.       **
+**                                                                        **
+**   You should have received a copy of the GNU  Lesser General Public    **
+**   License along with Timed. If not, see http://www.gnu.org/licenses/   **
+**                                                                        **
+***************************************************************************/
+
+#include "ntpcontroller.h"
+
+#include <QDBusInterface>
+#include <QDBusReply>
+#include <QDBusVariant>
+#include <QDBusServiceWatcher>
+
+#include "../common/log.h"
+
+const QLatin1String CONNMAN_SERVICE("net.connman");
+const QLatin1String CONNMAN_INTERFACE("net.connman.Clock");
+const QLatin1String CONNMAN_METHOD("SetProperty");
+
+NtpController::NtpController(bool enable, QObject *parent) :
+    QObject(parent), m_enable(enable)
+{
+    m_connmanWatcher = new QDBusServiceWatcher(CONNMAN_SERVICE,
+                                               QDBusConnection::systemBus(),
+                                               QDBusServiceWatcher::WatchForRegistration,
+                                               this);
+    connect(m_connmanWatcher, SIGNAL(serviceRegistered(QString)),
+            this, SLOT(serviceRegistered()));
+
+    enableNtpTimeAdjustment(m_enable);
+}
+
+void NtpController::enableNtpTimeAdjustment(bool enable)
+{
+    m_enable = enable;
+
+    QString parameter;
+    if (m_enable)
+        parameter = "auto";
+    else
+        parameter = "manual";
+
+    setConnmanProperty("TimeUpdates", parameter);
+    setConnmanProperty("TimezoneUpdates", parameter);
+}
+
+void NtpController::setConnmanProperty(QString key, QString value)
+{
+    QDBusMessage request = QDBusMessage::createMethodCall(CONNMAN_SERVICE,
+                                                          "/",
+                                                          CONNMAN_INTERFACE,
+                                                          CONNMAN_METHOD);
+    QList<QVariant> arguments;
+    arguments << key << QVariant::fromValue(QDBusVariant(value));
+    request.setArguments(arguments);
+    QDBusReply<void> reply = QDBusConnection::systemBus().call(request);
+    if (reply.error().isValid()) {
+        log_warning("Failed to call %s.%s: %s",
+                    QString(CONNMAN_INTERFACE).toStdString().c_str(),
+                    QString(CONNMAN_METHOD).toStdString().c_str(),
+                    reply.error().message().toStdString().c_str());
+    } else {
+        log_debug("Set %s property %s to value %s",
+                  QString(CONNMAN_INTERFACE).toStdString().c_str(),
+                  key.toStdString().c_str(),
+                  value.toStdString().c_str());
+    }
+}
+
+void NtpController::serviceRegistered()
+{
+    enableNtpTimeAdjustment(m_enable);
+}

--- a/src/server/ntpcontroller.h
+++ b/src/server/ntpcontroller.h
@@ -1,0 +1,47 @@
+/***************************************************************************
+**                                                                        **
+**  Copyright (C) 2013 Jolla Ltd.                                         **
+**  Contact: Petri M. Gerdt <petri.gerdt@jollamobile.com>                 **
+**                                                                        **
+**     This file is part of Timed                                         **
+**                                                                        **
+**     Timed is free software; you can redistribute it and/or modify      **
+**     it under the terms of the GNU Lesser General Public License        **
+**     version 2.1 as published by the Free Software Foundation.          **
+**                                                                        **
+**     Timed is distributed in the hope that it will be useful, but       **
+**     WITHOUT ANY WARRANTY;  without even the implied warranty  of       **
+**     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               **
+**     See the GNU Lesser General Public License  for more details.       **
+**                                                                        **
+**   You should have received a copy of the GNU  Lesser General Public    **
+**   License along with Timed. If not, see http://www.gnu.org/licenses/   **
+**                                                                        **
+***************************************************************************/
+
+#ifndef NTPCONTROLLER_H
+#define NTPCONTROLLER_H
+
+#include <QObject>
+
+class QDBusServiceWatcher;
+
+class NtpController : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit NtpController(bool enable, QObject *parent = 0);
+    void enableNtpTimeAdjustment(bool enable);
+
+public slots:
+    void serviceRegistered();
+
+private:
+    void setConnmanProperty(QString key, QString value);
+
+    bool m_enable;
+    QDBusServiceWatcher *m_connmanWatcher;
+};
+
+#endif // NTPCONTROLLER_H

--- a/src/server/server.pro
+++ b/src/server/server.pro
@@ -41,7 +41,8 @@ HEADERS += peer.h \
     networktimeinfo.h \
     ofonomodemmanager.h \
     modemwatcher.h \
-    ofonoconstants.h
+    ofonoconstants.h \
+    ntpcontroller.h
 
 SOURCES += peer.cpp \
     tzdata.cpp \
@@ -66,7 +67,8 @@ SOURCES += peer.cpp \
     networktimeinfo.cpp \
     ofonomodemmanager.cpp \
     modemwatcher.cpp \
-    ofonoconstants.cpp
+    ofonoconstants.cpp \
+    ntpcontroller.cpp
 
 SOURCES += credentials.cpp aegis.cpp
 HEADERS += credentials.h

--- a/src/server/settings.cpp
+++ b/src/server/settings.cpp
@@ -566,12 +566,15 @@ bool source_settings::wall_clock_settings(const Maemo::Timed::WallClock::wall_se
         set_system_time(nitz_utc->value_at_zero()) ;
         o->open_epoch() ;
       }
+      o->enable_ntp_time_adjustment(true);
       break ;
     case Op_Set_Time_Manual:
+      o->enable_ntp_time_adjustment(false);
       manual_utc->value = value_at_zero() ;
       time_nitz = false ;
       break ;
     case Op_Set_Time_Manual_Val:
+      o->enable_ntp_time_adjustment(false);
       time_nitz = false ;
       manual_utc->value = p.time_at_zero ;
       set_system_time(p.time_at_zero) ;

--- a/src/server/timed.cpp
+++ b/src/server/timed.cpp
@@ -61,6 +61,7 @@
 #include "notification.h"
 #include "time.h"
 #include "../common/log.h"
+#include "ntpcontroller.h"
 
 #include <string>
 #include <fstream>
@@ -160,6 +161,9 @@ Timed::Timed(int ac, char **av) :
 
   init_load_events() ;
   log_debug() ;
+
+  init_ntp();
+  log_debug();
 
 #if OFONO
   init_cellular_services() ;
@@ -692,6 +696,12 @@ void Timed::init_cellular_services()
 }
 #endif // OFONO
 
+
+void Timed::init_ntp()
+{
+  ntp_controller = new NtpController(settings->time_nitz, this);
+}
+
 void Timed::init_network_events()
 {
   network_configuration_manager = new QNetworkConfigurationManager(this);
@@ -852,6 +862,11 @@ bool Timed::dialog_response(cookie_t c, int value)
 {
   log_debug("Responded: %d(value=%d)", c.value(), value) ;
   return am->dialog_response(c, value) ;
+}
+
+void Timed::enable_ntp_time_adjustment(bool enable)
+{
+    ntp_controller->enableNtpTimeAdjustment(enable);
 }
 
 void Timed::system_owner_changed(const QString &name, const QString &oldowner, const QString &newowner)

--- a/src/server/timed.h
+++ b/src/server/timed.h
@@ -67,6 +67,8 @@ namespace statefs {
 }
 #endif
 
+class NtpController;
+
 struct Timed : public QCoreApplication
 {
 public:
@@ -126,6 +128,7 @@ private:
   void init_dst_checker() ;
   void init_start_event_machine() ;
   void init_cellular_services() ;
+  void init_ntp();
   void init_network_events() ;
   void init_apply_tz_settings() ;
   void init_kernel_notification() ;
@@ -160,6 +163,8 @@ public:
   void cancel_events(const QList<uint> &cookies, QList<uint> &failed) { am->cancel_events(cookies, failed) ;}
   void alarm_gate(bool value) { return am->alarm_gate(value) ; }
   int default_snooze(int value) { return settings->default_snooze(value) ; }
+  void enable_ntp_time_adjustment(bool enable);
+
   QDBusConnectionInterface *ses_iface ;
 
   map<int,unsigned> children ;
@@ -207,6 +212,7 @@ private:
   QTimer *dst_timer ;
   std::string sent_signature ;
   tz_oracle_t *tz_oracle ;
+  NtpController *ntp_controller;
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
   statefs::qt::InOutWriter *alarm_present;


### PR DESCRIPTION
Currently, the automatic time update is based only on the NITZ signal [1] that timed receives via ofono from the mobile network. Not all carriers support this, though.

Connman can be set to maintain time from NTP via D-bus [2]. This PR makes timed enable the NTP time adjustment feature of connman when automatic time updates is enabled.

[1] http://en.wikipedia.org/wiki/NITZ
[2] http://git.kernel.org/cgit/network/connman/connman.git/tree/doc/clock-api.txt?id=HEAD
