### PR TITLE
[timed] Remove half-implemented filter state that tracks network

### DIFF
--- a/rpm/timed-qt5.spec
+++ b/rpm/timed-qt5.spec
@@ -20,7 +20,6 @@ Requires(postun): /sbin/ldconfig
 BuildRequires:  pkgconfig(libpcrecpp)
 BuildRequires:  pkgconfig(Qt5Core)
 BuildRequires:  pkgconfig(Qt5DBus)
-BuildRequires:  pkgconfig(Qt5Network)
 BuildRequires:  pkgconfig(Qt5Test)
 BuildRequires:  pkgconfig(dsme_dbus_if)
 BuildRequires:  pkgconfig(systemd)

--- a/src/server/event.cpp
+++ b/src/server/event.cpp
@@ -305,7 +305,6 @@ void event_t::codec_initializer()
   recurrence_pattern_t::mons_codec = new iodata::bit_codec ;
 #define REG(codec_ptr, space, name) ((codec_ptr)->register_name(space::name, lowercase(#name)))
   REG(event_t::codec, EventFlags, Alarm) ;
-  REG(event_t::codec, EventFlags, Need_Connection) ;
   REG(event_t::codec, EventFlags, Trigger_If_Missed) ;
   REG(event_t::codec, EventFlags, Postpone_If_Missed) ;
   REG(event_t::codec, EventFlags, User_Mode) ;

--- a/src/server/flags.h
+++ b/src/server/flags.h
@@ -84,7 +84,6 @@ namespace WallOpcode
       enum
       {
         Alarm                   = 1<<0,
-        Need_Connection         = 1<<1,
         Trigger_If_Missed       = 1<<2,
         Postpone_If_Missed      = 1<<3,
         User_Mode               = 1<<4,

--- a/src/server/machine.h
+++ b/src/server/machine.h
@@ -94,8 +94,6 @@ struct machine_t : public QObject
   void send_queue_context() ;
   qlonglong running_time();
   Q_OBJECT ;
-public Q_SLOTS:
-  void online_state_changed(bool connected) ;
 Q_SIGNALS:
   void engine_pause(int dx) ;
   void voland_registered() ;
@@ -141,7 +139,6 @@ public:
   state_missed_t *state_missed ;
   state_due_t *state_due ;
   state_skipped_t *state_skipped ;
-  state_flt_conn_t *state_flt_conn ;
   state_flt_alrm_t *state_flt_alrm ;
   state_flt_user_t *state_flt_user ;
   state_snoozed_t *state_snoozed ;

--- a/src/server/server.pro
+++ b/src/server/server.pro
@@ -1,5 +1,5 @@
 QT -= gui
-QT += dbus network
+QT += dbus
 
 TEMPLATE = app
 

--- a/src/server/state.cpp
+++ b/src/server/state.cpp
@@ -307,7 +307,7 @@ void state_qentry_t::enter(event_t *e)
 {
   abstract_state_t::enter(e) ;
   log_assert(e->trigger.is_valid()) ;
-  machine->state_flt_conn->go_to(e) ;
+  machine->state_flt_alrm->go_to(e);
 }
 
 state_queued_t::state_queued_t(machine_t *owner) : abstract_io_state_t("QUEUED", owner)
@@ -459,11 +459,6 @@ void state_queued_t::filter_closed(abstract_filter_state_t *f_st)
   log_debug("event_found=%d", event_found) ;
   if(event_found)
     machine->process_transition_queue() ;
-}
-
-bool state_flt_conn_t::filter(event_t *e)
-{
-  return e->flags & EventFlags::Need_Connection ;
 }
 
 bool state_flt_alrm_t::filter(event_t *e)

--- a/src/server/state.h
+++ b/src/server/state.h
@@ -213,15 +213,6 @@ struct state_skipped_t : public abstract_state_t
   void enter(event_t *e) ;
 } ;
 
-struct state_flt_conn_t : public abstract_filter_state_t
-{
-  state_flt_conn_t(machine_t *owner) : abstract_filter_state_t("FLT_CONN", "QENTRY", "FLT_ALRM", owner) { }
-  virtual ~state_flt_conn_t() { }
-  uint32_t cluster_bits() { return EventFlags::Cluster_Queue ; }
-  bool filter(event_t *) ;
-  Q_OBJECT ;
-} ;
-
 struct state_flt_alrm_t : public abstract_filter_state_t
 {
   state_flt_alrm_t(machine_t *owner) : abstract_filter_state_t("FLT_ALRM", "QENTRY", "FLT_USER", owner) { }

--- a/src/server/timed.cpp
+++ b/src/server/timed.cpp
@@ -171,9 +171,6 @@ Timed::Timed(int ac, char **av) :
 
   log_debug() ;
 
-  init_network_events() ;
-  log_debug() ;
-
   init_dst_checker() ;
 
   log_debug("starting event mahine") ;
@@ -700,15 +697,6 @@ void Timed::init_cellular_services()
 void Timed::init_ntp()
 {
   ntp_controller = new NtpController(settings->time_nitz, this);
-}
-
-void Timed::init_network_events()
-{
-  network_configuration_manager = new QNetworkConfigurationManager(this);
-  connect(network_configuration_manager, SIGNAL(onlineStateChanged(bool)), am, SLOT(online_state_changed(bool))) ;
-  bool connected_now = network_configuration_manager->isOnline() ;
-  if (connected_now)
-    am->online_state_changed(true) ;
 }
 
 void Timed::init_dst_checker()

--- a/src/server/timed.h
+++ b/src/server/timed.h
@@ -28,7 +28,6 @@
 #include <QMetaMethod>
 #include <QDBusConnectionInterface>
 #include <QDBusServiceWatcher>
-#include <QNetworkConfigurationManager>
 
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
 #include <ContextProvider>
@@ -129,7 +128,6 @@ private:
   void init_start_event_machine() ;
   void init_cellular_services() ;
   void init_ntp();
-  void init_network_events() ;
   void init_apply_tz_settings() ;
   void init_kernel_notification() ;
 
@@ -250,7 +248,6 @@ public:
   void device_mode_reached(bool act_dead, const std::string &dbus_session) ;
 #endif
   void device_mode_reached(bool user_mode) ;
-  QNetworkConfigurationManager *network_configuration_manager ;
 #if 0
   void nitz_notification(const cellular_info_t &) ;
   void tz_by_oracle(olson *tz, tz_suggestions_t) ;


### PR DESCRIPTION
Remove state_flt_conn to cut down the complexity of the timed state machine.

The state state_flt_conn filters events based on whether a network connection is available. However, timed has no public API for enabling network tracking in events.

Removing the state will not affect existing alarms, which could not use the feature because of missing API.
