### PR TITLE
[rpm] Reinstate execute bits for setcaps helper script. Fixes JB#23021

### DIFF
--- a/rpm/timed-qt5.spec
+++ b/rpm/timed-qt5.spec
@@ -84,6 +84,9 @@ rm -rf %{buildroot}
 install -d %{buildroot}%{_libdir}/systemd/user/pre-user-session.target.wants/
 ln -s ../%{name}.service %{buildroot}%{_libdir}/systemd/user/pre-user-session.target.wants/%{name}.service
 
+# Missing executable flags.
+chmod 755 %{buildroot}%{_oneshotdir}/setcaps-%{name}.sh
+
 # Timed changes time zone by linking /var/lib/timed/localtime to zones in /usr/share/zoneinfo.
 # Initial links are done in the post section
 install -d %{buildroot}/var/lib/timed


### PR DESCRIPTION
While removing unused legacy files and scripts from timed rpm, the
chmod that makes setcaps-timed-qt5.sh executable was also removed
and timed lost the ability to change the system time.

Restore the lines that should not have been removed.
