### PR TITLE
Don't use blocking QtDBus API features

### DIFF
--- a/src/common/log.h
+++ b/src/common/log.h
@@ -42,8 +42,8 @@
 # define log_debug(FMT,ARGS...) \
     do { \
         printf("DEBUG: %s:%d: %s", __FILE__, __LINE__, Q_FUNC_INFO); \
-        if (strlen(""FMT) > 0) \
-            printf(":\n- "FMT"\n", ## ARGS); \
+        if (strlen("" FMT) > 0) \
+            printf(":\n- " FMT "\n", ## ARGS); \
         else \
             printf("\n"); \
     } while(0)
@@ -52,31 +52,31 @@
 #endif
 
 #if LOG_LEVEL >= LOG_INFO
-# define log_info(FMT,ARGS...) do { fprintf(stderr, "INFO: "FMT"\n", ## ARGS); } while(0)
+# define log_info(FMT,ARGS...) do { fprintf(stderr, "INFO: " FMT "\n", ## ARGS); } while(0)
 #else
 # define log_info(FMT,ARGS...) do { } while(0)
 #endif
 
 #if LOG_LEVEL >= LOG_INFO
-# define log_notice(FMT,ARGS...) do { fprintf(stderr, "NOTICE: "FMT"\n", ## ARGS); } while(0)
+# define log_notice(FMT,ARGS...) do { fprintf(stderr, "NOTICE: " FMT "\n", ## ARGS); } while(0)
 #else
 # define log_notice(FMT,ARGS...) do { } while(0)
 #endif
 
 #if LOG_LEVEL >= LOG_WARNING
-# define log_warning(FMT,ARGS...) do { fprintf(stderr, "WARNING: "FMT"\n", ## ARGS); } while(0)
+# define log_warning(FMT,ARGS...) do { fprintf(stderr, "WARNING: " FMT "\n", ## ARGS); } while(0)
 #else
 # define log_warning(FMT,ARGS...) do { } while(0)
 #endif
 
 #if LOG_LEVEL >= LOG_ERROR
-# define log_error(FMT,ARGS...) do { fprintf(stderr, "ERROR: "FMT"\n", ## ARGS); } while(0)
+# define log_error(FMT,ARGS...) do { fprintf(stderr, "ERROR: " FMT "\n", ## ARGS); } while(0)
 #else
 # define log_error(FMT,ARGS...) do { } while(0)
 #endif
 
 #if LOG_LEVEL >= LOG_CRITICAL
-# define log_critical(FMT,ARGS...) do { fprintf(stderr, "CRITICAL: "FMT"\n", ## ARGS); } while(0)
+# define log_critical(FMT,ARGS...) do { fprintf(stderr, "CRITICAL: " FMT "\n", ## ARGS); } while(0)
 #else
 # define log_critical(FMT,ARGS...) do { } while(0)
 #endif
@@ -85,10 +85,10 @@
 # define log_assert(COND, ARGS...) \
     do { \
         if (!(COND)) \
-            fprintf(stderr, "ASSERT: "ARGS); \
+            fprintf(stderr, "ASSERT: " ARGS); \
         assert(COND); \
     } while(0)
-# define log_abort(FMT,ARGS...) do { fprintf(stderr, "ABORT: "FMT"\n", ## ARGS); assert(0); } while(0)
+# define log_abort(FMT,ARGS...) do { fprintf(stderr, "ABORT: " FMT "\n", ## ARGS); assert(0); } while(0)
 #else
 # define log_assert(COND, ARGS...) do { assert(COND); } while(0)
 # define log_abort(FMT,ARGS...) do { assert(0); } while(0)

--- a/src/server/modemwatcher.cpp
+++ b/src/server/modemwatcher.cpp
@@ -19,8 +19,10 @@
 **                                                                        **
 ***************************************************************************/
 
-#include <QDBusInterface>
-#include <QDBusReply>
+#include <QtDBus/QDBusInterface>
+#include <QtDBus/QDBusReply>
+#include <QtDBus/QDBusServiceWatcher>
+#include <QtDBus/QDBusConnectionInterface>
 
 #include "../common/log.h"
 
@@ -31,15 +33,37 @@ ModemWatcher::ModemWatcher(const QString objectPath, const QString interface, QO
     QObject(parent), m_objectPath(objectPath), m_interface(interface), m_interfaceAvailable(false)
 {
     QDBusConnection::systemBus().connect(OfonoConstants::OFONO_SERVICE, m_objectPath,
-                                         OfonoConstants::OFONO_MODEM_INTERFACE, "PropertyChanged",
-                                         this, SLOT(onModemPropertyChanged(QString, QDBusVariant)));
+                                         OfonoConstants::OFONO_MODEM_INTERFACE,
+                                         "PropertyChanged", this,
+                                         SLOT(onModemPropertyChanged(QString, QDBusVariant)));
 
+    m_ofonoWatcher = new QDBusServiceWatcher(OfonoConstants::OFONO_SERVICE,
+                                             QDBusConnection::systemBus(),
+                                             QDBusServiceWatcher::WatchForRegistration,
+                                             this);
+    connect(m_ofonoWatcher, SIGNAL(serviceRegistered(QString)),
+            this, SLOT(getProperties()));
+
+    if (QDBusConnection::systemBus().interface()->isServiceRegistered(OfonoConstants::OFONO_SERVICE))
+        getProperties();
+}
+
+void ModemWatcher::getProperties()
+{
     QDBusMessage request = QDBusMessage::createMethodCall(OfonoConstants::OFONO_SERVICE,
                                                           m_objectPath,
                                                           OfonoConstants::OFONO_MODEM_INTERFACE,
                                                           "GetProperties");
+    QDBusPendingReply<QVariantMap> reply = QDBusConnection::systemBus().asyncCall(request);
+    QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(reply, this);
+    QObject::connect(watcher, SIGNAL(finished(QDBusPendingCallWatcher*)),
+                     this, SLOT(getPropertiesReply(QDBusPendingCallWatcher*)));
+}
 
-    QDBusReply<QVariantMap> reply = QDBusConnection::systemBus().call(request);
+void ModemWatcher::getPropertiesReply(QDBusPendingCallWatcher *call)
+{
+    QDBusPendingReply<QVariantMap> reply = *call;
+    call->deleteLater();
     if (reply.error().isValid()) {
         log_error("DBus call to interface %s function GetProperties of path %s failed: %s",
                   m_interface.toStdString().c_str(),
@@ -47,6 +71,7 @@ ModemWatcher::ModemWatcher(const QString objectPath, const QString interface, QO
                   reply.error().message().toStdString().c_str());
     } else {
         QVariantMap properties = reply;
+
         checkInterfaceAvailability(properties.value("Interfaces"));
     }
 }
@@ -76,22 +101,21 @@ QString ModemWatcher::interface() const
 // Checks if the interface stored in m_interface is present in
 // list of interfaces stored in parameter variant.
 // Changes m_interfaceAvailable to reflect interface presence in
-// the list: true indicates that the interface is in the list, false
-// indicates that it is not. If m_interfaceAvailable was changed,
-// then returns true, otherwise returns false.
-bool ModemWatcher::checkInterfaceAvailability(QVariant variant)
+// the list and emits the change signal interfaceAvailableChanged
+void ModemWatcher::checkInterfaceAvailability(QVariant variant)
 {
     if (variant.type() != QVariant::StringList)
-        return false;
+        return;
 
     QStringList list = variant.toStringList();
     bool available = list.contains(m_interface);
     if (available != m_interfaceAvailable) {
         m_interfaceAvailable = available;
-        return true;
+        emit interfaceAvailableChanged(m_interfaceAvailable);
+        log_debug("interface %s availability changed: %s",
+                  m_interface.toStdString().c_str(),
+                  m_interfaceAvailable ? "available" : "not available");
     }
-
-    return false;
 }
 
 void ModemWatcher::onModemPropertyChanged(QString name, QDBusVariant value)
@@ -99,10 +123,5 @@ void ModemWatcher::onModemPropertyChanged(QString name, QDBusVariant value)
     if (name.compare("Interfaces") != 0)
         return;
 
-    if (checkInterfaceAvailability(value.variant())) {
-        log_debug("interface %s availability changed: %s",
-                  m_interface.toStdString().c_str(),
-                  m_interfaceAvailable ? "available" : "not available");
-        emit interfaceAvailableChanged(m_interfaceAvailable);
-    }
+    checkInterfaceAvailability(value.variant());
 }

--- a/src/server/modemwatcher.h
+++ b/src/server/modemwatcher.h
@@ -28,6 +28,7 @@
 
 class QDBusInterface;
 class QDBusPendingCallWatcher;
+class QDBusServiceWatcher;
 
 class ModemWatcher : public QObject
 {
@@ -47,9 +48,13 @@ private:
     QString m_objectPath;
     QString m_interface;
     bool m_interfaceAvailable;
-    bool checkInterfaceAvailability(QVariant variant);
+    QDBusServiceWatcher *m_ofonoWatcher;
+
+    void checkInterfaceAvailability(QVariant variant);
 
 private slots:
     void onModemPropertyChanged(QString objectPath, QDBusVariant value);
+    void getProperties();
+    void getPropertiesReply(QDBusPendingCallWatcher *call);
 };
 #endif // MODEMWATCHER_H

--- a/src/server/networkoperator.cpp
+++ b/src/server/networkoperator.cpp
@@ -29,7 +29,7 @@
 NetworkOperator::NetworkOperator(QObject *parent) :
     QObject(parent), m_mccUpdated(false), m_mncUpdated(false)
 {
-    foreach (const QString objectPath, m_modemManager.getModems())
+    foreach (const QString objectPath, m_modemManager.getModemList())
         onModemAdded(objectPath);
 
     QObject::connect(&m_modemManager, SIGNAL(modemAdded(QString)),
@@ -70,8 +70,8 @@ void NetworkOperator::onModemAdded(QString objectPath)
     NetworkRegistrationWatcher *watcher = new NetworkRegistrationWatcher(objectPath, this);
     QObject::connect(watcher, SIGNAL(propertyChanged(QString, QString, QVariant)),
                      this, SLOT(onWatcherPropertyChanged(QString, QString, QVariant)));
-    watcher->getProperties();
     m_watcherMap.insert(objectPath, watcher);
+    watcher->getProperties();
 }
 
 void NetworkOperator::onModemRemoved(QString objectPath)

--- a/src/server/networkregistrationwatcher.h
+++ b/src/server/networkregistrationwatcher.h
@@ -38,6 +38,7 @@ public:
     explicit NetworkRegistrationWatcher(const QString objectPath, QObject *parent = 0);
     ~NetworkRegistrationWatcher();
 
+public slots:
     void getProperties();
 
 signals:
@@ -45,7 +46,6 @@ signals:
 
 private slots:
     void onPropertyChanged(QString name, QDBusVariant value);
-    void getPropertiesAsync();
-    void getPropertiesAsyncCallback(QDBusPendingCallWatcher *watcher);
+    void getPropertiesCallback(QDBusPendingCallWatcher *watcher);
 };
 #endif // NETWORKREGISTRATIONRWATCHER_H

--- a/src/server/networktime.cpp
+++ b/src/server/networktime.cpp
@@ -30,7 +30,7 @@
 NetworkTime::NetworkTime(QObject *parent) :
     QObject(parent)
 {
-    foreach (const QString objectPath, m_modemManager.getModems())
+    foreach (const QString objectPath, m_modemManager.getModemList())
         onModemAdded(objectPath);
 
     QObject::connect(&m_modemManager, SIGNAL(modemAdded(QString)),

--- a/src/server/ntpcontroller.cpp
+++ b/src/server/ntpcontroller.cpp
@@ -21,11 +21,12 @@
 
 #include "ntpcontroller.h"
 
-#include <QDBusInterface>
-#include <QDBusReply>
-#include <QDBusVariant>
-#include <QDBusServiceWatcher>
+#include <QtDBus/QDBusInterface>
+#include <QtDBus/QDBusReply>
+#include <QtDBus/QDBusVariant>
+#include <QtDBus/QDBusServiceWatcher>
 #include <QtDBus/QDBusPendingCallWatcher>
+#include <QtDBus/QDBusConnectionInterface>
 
 #include "../common/log.h"
 
@@ -42,8 +43,8 @@ NtpController::NtpController(bool enable, QObject *parent) :
                                                this);
     connect(m_connmanWatcher, SIGNAL(serviceRegistered(QString)),
             this, SLOT(serviceRegistered()));
-    QDBusInterface connmanInterface(CONNMAN_SERVICE, "/",  CONNMAN_INTERFACE, QDBusConnection::systemBus());
-    if (connmanInterface.isValid())
+
+    if (QDBusConnection::systemBus().interface()->isServiceRegistered(CONNMAN_SERVICE))
         enableNtpTimeAdjustment(m_enable);
 }
 

--- a/src/server/ofonomodemmanager.h
+++ b/src/server/ofonomodemmanager.h
@@ -27,7 +27,8 @@
 #include <QStringList>
 #include <QVariant>
 
-class ModemWatcher;
+class QDBusServiceWatcher;
+class QDBusPendingCallWatcher;
 
 class OfonoModemManager : public QObject
 {
@@ -37,7 +38,7 @@ public:
     explicit OfonoModemManager(QObject *parent = 0);
     ~OfonoModemManager();
 
-    QStringList getModems();
+    QStringList getModemList();
 
 signals:
     void modemAdded(QString objectPath);
@@ -46,10 +47,14 @@ signals:
 private slots:
     void onModemAdded(QDBusObjectPath objectPath, QVariantMap map);
     void onModemRemoved(QDBusObjectPath objectPath);
+    void serviceRegistered();
+    void getModemsReply(QDBusPendingCallWatcher *call);
 
 private:
     QStringList m_modemList;
+    QDBusServiceWatcher *m_ofonoWatcher;
     bool addModem(QString objectPath);
+    void getModems();
 };
 
 #endif // OFONOMODEMMANAGER_H

--- a/src/server/timed-qt5.service
+++ b/src/server/timed-qt5.service
@@ -3,6 +3,7 @@ Description=Time Daemon
 Requires=dbus.socket
 After=dbus.socket
 
+# Service type should be dbus, but timed dbus API is on the system bus, which systemd does not detect
 [Service]
 Type=notify
 ExecStart=/usr/bin/timed-qt5 --systemd


### PR DESCRIPTION
Timed must not block if Ofono is unresponsive, in addition watch the Ofono DBus interface and (re)connect when it appears. Contributes to JB#29980.

Verify that Ofono and connman services are registered before attempting to use them.

Some compilation warning cleanup in log.h included, too.